### PR TITLE
Now only approved applicant can revoke approval

### DIFF
--- a/app/models/adopt_application.rb
+++ b/app/models/adopt_application.rb
@@ -3,4 +3,8 @@ class AdoptApplication < ApplicationRecord
                         :zip, :phone, :description
   has_many :pet_applications
   has_many :pets, through: :pet_applications
+
+  def is_approved_for_pet?(pet_id)
+    pet_applications.find_by(pet_id: pet_id).approval
+  end
 end

--- a/app/views/adopt_applications/show.html.erb
+++ b/app/views/adopt_applications/show.html.erb
@@ -9,7 +9,7 @@
 <% @applicant.pets.each do |pet| %>
   <section class = "app-<%= pet.id  %>">
     <%= link_to pet.name, "/pets/#{pet.id}" %><br/>
-    <% if pet.is_adoptable? %>
+    <% if !@applicant.is_approved_for_pet?(pet.id) %>
       <%= button_to "Approve Application", "/pets/#{pet.id}/applications", method: :patch, params: {applicant: @applicant.id} %>
     <% else %>
       <%= button_to "Revoke Approval", "/pets/#{pet.id}/applications", method: :delete, params: {applicant: @applicant.id} %>

--- a/spec/features/application/application_update_spec.rb
+++ b/spec/features/application/application_update_spec.rb
@@ -83,8 +83,10 @@ RSpec.describe "Approving an Application", type: :feature do
 
     visit "/applications/#{john_jones.id}"
     within ".app-#{@sonic.id}" do
-      expect(page).to_not have_button("Approve Application")
+      click_button("Approve Application")
     end
+    expect(page).to have_content("#{@sonic.name} is pending adoption elsewhere.")
+    expect(current_path).to eq("/applications/#{john_jones.id}")
 
     visit "/pets/#{@sonic.id}/applications"
     expect(page).to have_content("#{john_jones.name}")

--- a/spec/models/adopt_application_spec.rb
+++ b/spec/models/adopt_application_spec.rb
@@ -14,4 +14,56 @@ describe AdoptApplication, type: :model do
     it { should have_many :pet_applications}
     it { should have_many(:pets).through(:pet_applications)}
   end
+  describe "methods" do
+    before :each do
+      @francis = AdoptApplication.create(name: "Francis",
+                                         address: "2080 S. Quebec St.",
+                                         city: "Denver",
+                                         state: "CO",
+                                         zip: "80231",
+                                         phone: "2023332291",
+                                         description: "I am a perfect human.")
+
+      @shelter = Shelter.create(name: "Dumb Friends League",
+                                 address: "2080 S. Quebec St.",
+                                 city: "Denver",
+                                 state: "CO",
+                                 zip: "80231")
+
+      @cassidy = Pet.create(image: "cute_dog.jpg",
+                         name: "Cassidy",
+                         description: "A very adorable pupper.",
+                         approx_age: 10,
+                         sex: "F",
+                         adopt_status: 'pending',
+                         shelter_id: @shelter.id)
+
+      @hobbes = Pet.create(image: "smug_cat.jpg",
+                         name: "Hobbes",
+                         description: "A mischievous cat.",
+                         approx_age: 5,
+                         sex: "M",
+                         adopt_status: 'pending',
+                         shelter_id: @shelter.id)
+
+      @john_jones = AdoptApplication.create(name: "John Jones",
+                                  address: "Mars St",
+                                  city: "Mars Capital",
+                                  state: "MS",
+                                  zip: "99999",
+                                  phone: "9991112233",
+                                  description: "Looking for an animal from a different planet.")
+
+      PetApplication.create(pet_id: @cassidy.id, adopt_application_id: @francis.id, approval: false)
+      PetApplication.create(pet_id: @hobbes.id, adopt_application_id: @francis.id, approval: true)
+      PetApplication.create(pet_id: @cassidy.id, adopt_application_id: @john_jones.id, approval: true)
+    end
+
+    it "#is_approved_for_pet?" do
+      expect(@francis.is_approved_for_pet?(@hobbes.id)).to eq(true)
+      expect(@francis.is_approved_for_pet?(@cassidy.id)).to eq(false)
+      expect(@john_jones.is_approved_for_pet?(@cassidy.id)).to eq(true)
+    end
+
+  end
 end


### PR DESCRIPTION
Previously the revoke approval button would show on any application page with an approved pet, now only shows on the application for which the pet is approved - all others will get an error message if they try and click approve application